### PR TITLE
[FIX] URL encoding

### DIFF
--- a/bin/lib/api.js
+++ b/bin/lib/api.js
@@ -9,7 +9,8 @@ const apiThresholds = {
 };
 
 async function getClassification(imageUrl) {
-	const postData = `image=${imageUrl}`;
+	console.log(encodeURIComponent(imageUrl));
+	const postData = `image=${encodeURIComponent(imageUrl)}`;
 
 	const options = {
 		headers: {


### PR DESCRIPTION
- encodes urls so `width=500` isn't lost on the API side