### PR TITLE
[FIX] image URL formatting

### DIFF
--- a/bin/lib/homepage.js
+++ b/bin/lib/homepage.js
@@ -60,7 +60,8 @@ async function getImagesFor(list, layout, sectionID, edition) {
 			let imageData = await getTeaser(Utils.extractUUID(list[indices[i]]));
 
 			if(imageData.images.length) {
-				const formattedURL = await Utils.formatUrl(imageData.images[0].binaryUrl);
+				const formattedURL = await Utils.formatUrl(imageData.images[0]);
+
 				const image = {
 					timestamp: new Date().getTime(),
 					edition: edition,

--- a/bin/lib/utils.js
+++ b/bin/lib/utils.js
@@ -60,14 +60,8 @@ function setPlaceholderURL(url) {
 }
 
 async function formatImageUrl(url) {
-	let apiUrls = process.env.API_IMG_URL.split(',');
-	let format;
-
-	for (let i = 0; i < apiUrls.length; ++i) {
-		format = url.replace(apiUrls[i], process.env.REPLACE_IMG_URL);
-	}
-
-	format = format.concat('?source=janetbot&quality=low&width=500');
+	const uuid = extractUUID(url);
+	const format = `${process.env.REPLACE_IMG_URL}${uuid}?source=janetbot&quality=low&width=500`;
 
 	return format;
 }


### PR DESCRIPTION
replace image url formatting with a more consistent result, using `apiUrl` property instead of `binaryUrl`